### PR TITLE
Adjust Welcome spacing for mobile

### DIFF
--- a/src/components/Welcome/Welcome.tsx
+++ b/src/components/Welcome/Welcome.tsx
@@ -15,7 +15,7 @@ export default function Welcome({ firstName = "World" }: WelcomeProps) {
   const currentDate = `${weekday}, ${month} ${dayWithSuffix}, ${year}`;
 
   return (
-    <div className="py-16 text-center flex flex-col gap-2.5">
+    <div className="flex flex-col text-center py-12 md:gap-2.5 gap-4 lg:py-16">
       <p className="text-t3 text-blue-600">Hello, {firstName}!</p>
       <h1 className="text-t1 text-neutral-900">How are you feeling today?</h1>
       <p className="text-t6 text-neutral-600">{currentDate}</p>


### PR DESCRIPTION
Closes https://github.com/czenko/mood-tracker/issues/22

## Problem

The Welcome component was introduced, but the spacing was not adjusted for various breakpoints.

## Solution

This PR does the following:

- Adds 48px padding until desktop breakpoint
- Adds 16px gap until mobile breakpoint

<img width="374" alt="Screenshot 2025-07-02 at 2 51 04 PM" src="https://github.com/user-attachments/assets/a5723b9c-96d2-4588-97ae-da9c6a68a309" />


## Tophatting

1. Run `npm run storybook` locally.
2. Cross-reference spacing with mobile, tablet, and desktop breakpoints.
3. See they are consistent.

**Note:** I spotted an inconsistency screenshotted below. Given that none of the other mockups appear like this, I believe it's an error.

<img width="114" alt="Screenshot 2025-07-02 at 2 52 31 PM" src="https://github.com/user-attachments/assets/840c7e8c-5b6f-44b3-80bc-1d1d60d90901" />

