### PR TITLE
Create PrevCheckins component

### DIFF
--- a/src/components/PrevCheckins/ArrowRight.tsx
+++ b/src/components/PrevCheckins/ArrowRight.tsx
@@ -4,19 +4,19 @@ interface ArrowRightProps {
   width?: number;
   height?: number;
   fill?: string;
-  variant?: "default" | "increase" | "decrease";
+  variant?: "neutral" | "increase" | "decrease";
 }
 
 const arrowRightVariants = cva("inline-block", {
   variants: {
     variant: {
-      default: "rotate-0",
+      neutral: "rotate-0",
       increase: "-rotate-45",
       decrease: "rotate-45",
     },
   },
   defaultVariants: {
-    variant: "default",
+    variant: "neutral",
   },
 });
 
@@ -24,7 +24,7 @@ const ArrowRight: React.FC<ArrowRightProps> = ({
   width = 15,
   height = 16,
   fill = "#21214D",
-  variant = "default",
+  variant = "neutral",
 }) => {
   return (
     <svg

--- a/src/components/PrevCheckins/ArrowRight.tsx
+++ b/src/components/PrevCheckins/ArrowRight.tsx
@@ -1,0 +1,47 @@
+import { cva } from "class-variance-authority";
+
+interface ArrowRightProps {
+  width?: number;
+  height?: number;
+  fill?: string;
+  variant?: "default" | "increase" | "decrease";
+}
+
+const arrowRightVariants = cva("inline-block", {
+  variants: {
+    variant: {
+      default: "rotate-0",
+      increase: "-rotate-45",
+      decrease: "rotate-45",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
+
+const ArrowRight: React.FC<ArrowRightProps> = ({
+  width = 15,
+  height = 16,
+  fill = "#21214D",
+  variant = "default",
+}) => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 15 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={arrowRightVariants({ variant })}
+      aria-hidden="true"
+    >
+      <path
+        d="M7.53851 1.47761C7.65854 1.32756 7.89862 1.32756 8.04867 1.47761L14.3207 7.74966C14.4708 7.89971 14.4708 8.10978 14.3207 8.25983L8.04867 14.5319C7.89862 14.6819 7.65855 14.6819 7.53851 14.5319L6.93831 13.9617C6.78826 13.8117 6.78826 13.5716 6.93831 13.4515L11.5898 8.77L1.35648 8.77C1.14641 8.77 0.996361 8.61995 0.996361 8.40988L0.996362 7.5696C0.996361 7.38955 1.14641 7.20949 1.35648 7.20949L11.5898 7.20949L6.93831 2.55796C6.78826 2.43792 6.78826 2.19784 6.93831 2.0478L7.53851 1.47761Z"
+        fill={fill}
+      />
+    </svg>
+  );
+};
+
+export default ArrowRight;

--- a/src/components/PrevCheckins/PrevCheckins.stories.ts
+++ b/src/components/PrevCheckins/PrevCheckins.stories.ts
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+import PrevCheckins from "./PrevCheckins";
+
+const meta = {
+  title: "Dashboard/PrevCheckins",
+  component: PrevCheckins,
+
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Shows the trend of the user's checkins over the past 5 days.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof PrevCheckins>;
+
+// Create primary story
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    hasData: true,
+    variant: "mood",
+    state: "default",
+  },
+};

--- a/src/components/PrevCheckins/PrevCheckins.stories.ts
+++ b/src/components/PrevCheckins/PrevCheckins.stories.ts
@@ -26,6 +26,6 @@ export const Primary: Story = {
   args: {
     hasData: true,
     variant: "mood",
-    state: "default",
+    state: "neutral",
   },
 };

--- a/src/components/PrevCheckins/PrevCheckins.tsx
+++ b/src/components/PrevCheckins/PrevCheckins.tsx
@@ -1,0 +1,50 @@
+import { cva } from "class-variance-authority";
+import ArrowRight from "./ArrowRight";
+
+interface PrevCheckinsProps {
+  hasData: boolean;
+  variant: "mood" | "sleep";
+  state: "default" | "increase" | "decrease";
+}
+
+const prevCheckinsVariants = cva("text-t7 text-neutral-900", {
+  variants: {
+    variant: {
+      mood: "",
+      sleep: "opacity-70",
+    },
+  },
+});
+
+export default function PrevCheckins({
+  hasData = false,
+  variant = "mood",
+  state = "default",
+}: PrevCheckinsProps) {
+  const noDataCopy = {
+    mood: "Log 5 check-ins to see your average mood.",
+    sleep: "Track 5 nights to view average sleep.",
+  };
+  const changeCopy = {
+    default: "Same as",
+    increase: "Increase from",
+    decrease: "Decrease from",
+  };
+
+  if (!hasData) {
+    return (
+      <p className="text-t7 text-neutral-900 opacity-70">
+        {noDataCopy[variant]}
+      </p>
+    );
+  }
+
+  return (
+    <p className={prevCheckinsVariants({ variant })}>
+      <span className="inline-block mr-2">
+        <ArrowRight variant={state} />
+      </span>
+      <span>{changeCopy[state]} the previous 5 check-ins</span>
+    </p>
+  );
+}

--- a/src/components/PrevCheckins/PrevCheckins.tsx
+++ b/src/components/PrevCheckins/PrevCheckins.tsx
@@ -4,7 +4,7 @@ import ArrowRight from "./ArrowRight";
 interface PrevCheckinsProps {
   hasData: boolean;
   variant: "mood" | "sleep";
-  state: "default" | "increase" | "decrease";
+  state: "neutral" | "increase" | "decrease";
 }
 
 const prevCheckinsVariants = cva("text-t7 text-neutral-900", {
@@ -19,14 +19,14 @@ const prevCheckinsVariants = cva("text-t7 text-neutral-900", {
 export default function PrevCheckins({
   hasData = false,
   variant = "mood",
-  state = "default",
+  state = "neutral",
 }: PrevCheckinsProps) {
   const noDataCopy = {
     mood: "Log 5 check-ins to see your average mood.",
     sleep: "Track 5 nights to view average sleep.",
   };
   const changeCopy = {
-    default: "Same as",
+    neutral: "Same as",
     increase: "Increase from",
     decrease: "Decrease from",
   };


### PR DESCRIPTION
Closes https://github.com/czenko/mood-tracker/issues/26


https://github.com/user-attachments/assets/747acdf0-750a-4cf5-8533-88255056d6ef

## Problem

The average sleep and average mood cards share the majority of functionality.

Therefore, it makes sense to write a shared component that handles all variants.

<img width="172" alt="Screenshot 2025-07-01 at 12 12 40 PM" src="https://github.com/user-attachments/assets/bd0f3798-0e13-44fd-9f1e-e632cadb5f03" />

## Solution

This PR creates a PrevCheckins that includes variants for all of the states for both mood and sleep.

This component changes its content and icon based on the props.

**Note the props used:**
```
interface PrevCheckinsProps {
  hasData: boolean;
  variant: "mood" | "sleep";
  state: "default" | "increase" | "decrease";
}
```

`hasData` is separate from states for ease of use. The parent component can handle the data to first determine if there's enough data.

The three states match 1-1 with the `ArrowRight` component for easy transferability.

## Tophatting

1. Run `npm run storybook` and go to the PrevCheckins component
2. Toggle the different variants and compare to all of the states in the Figma.
3. See that the Figma and Storybook match.